### PR TITLE
Qualys vulnerability node enhancement

### DIFF
--- a/connectors/qualys/app.py
+++ b/connectors/qualys/app.py
@@ -24,6 +24,9 @@ class App(BaseApp):
                                  type=str, required=False, help='Username for the Qualys data source')
         self.parser.add_argument('-password', dest='password', default=os.getenv('CONFIGURATION_AUTH_PASSWORD', None),
                                  type=str, required=False, help='Password for the Qualys data source')
+        self.parser.add_argument('-update_existing_vulnerability_cve', dest='update_existing_vulnerability_cve',
+                                 action='store_true', default=os.getenv('UPDATE_EXISTING_VULNERABILITY_CVE', False),
+                                 help='Update existing vulnerability nodes with CVE information')
 
     def setup(self):
         super().setup()

--- a/connectors/qualys/automation_tests/automation_tests.py
+++ b/connectors/qualys/automation_tests/automation_tests.py
@@ -30,6 +30,7 @@ class Arguments:
     debug = None
     connector_name = args['source']
     gateway = ''
+    update_existing_vulnerability_cve = False
 
 
 def get_response(filename, json_format=None):
@@ -69,7 +70,12 @@ class TestConnector(unittest.TestCase):
         mock_application_detail = Mock(status_code=200)
         mock_application_detail.json.return_value = res_app_detail
 
-        mock_api.side_effect = [mock_host_asset, mock_vulnerability_detail, mock_header, mock_application_detail]
+        # Mock vulnerability kb details for detections
+        vuln_kb = get_response('vulnerability_kb_details.xml')
+        mock_kb = Mock(status_code=200)
+        mock_kb.text = vuln_kb
+
+        mock_api.side_effect = [mock_host_asset, mock_vulnerability_detail, mock_kb, mock_header, mock_application_detail]
 
         # Initialization
         Context(Arguments)
@@ -105,7 +111,12 @@ class TestConnector(unittest.TestCase):
         mock_application_detail = Mock(status_code=200)
         mock_application_detail.json.return_value = res_app_detail
 
-        mock_api.side_effect = [mock_host_asset, mock_vulnerability_detail, mock_header, mock_application_detail]
+        # Mock vulnerability kb details for detections
+        vuln_kb = get_response('vulnerability_kb_details.xml')
+        mock_kb = Mock(status_code=200)
+        mock_kb.text = vuln_kb
+
+        mock_api.side_effect = [mock_host_asset, mock_vulnerability_detail, mock_kb, mock_header, mock_application_detail]
 
         # Initialization
         Context(Arguments)
@@ -143,7 +154,12 @@ class TestConnector(unittest.TestCase):
         mock_application_detail = Mock(status_code=200)
         mock_application_detail.json.return_value = res_app_detail
 
-        mock_api.side_effect = [mock_host_asset, mock_vulnerability_detail, mock_header, mock_application_detail]
+        # Mock vulnerability kb details for detections
+        vuln_kb = get_response('vulnerability_kb_details.xml')
+        mock_kb = Mock(status_code=200)
+        mock_kb.text = vuln_kb
+
+        mock_api.side_effect = [mock_host_asset, mock_vulnerability_detail, mock_kb, mock_header, mock_application_detail]
 
         # Initialization
         Context(Arguments)
@@ -185,7 +201,12 @@ class TestConnector(unittest.TestCase):
         mock_application_detail = Mock(status_code=200)
         mock_application_detail.json.return_value = res_app_detail
 
-        mock_api.side_effect = [mock_host_asset, mock_vulnerability_detail, mock_header, mock_application_detail]
+        # Mock vulnerability kb details for detections
+        vuln_kb = get_response('vulnerability_kb_details.xml')
+        mock_kb = Mock(status_code=200)
+        mock_kb.text = vuln_kb
+
+        mock_api.side_effect = [mock_host_asset, mock_vulnerability_detail, mock_kb, mock_header, mock_application_detail]
 
         # Initialization
         Context(Arguments)
@@ -228,7 +249,12 @@ class TestConnector(unittest.TestCase):
         mock_application_detail = Mock(status_code=200)
         mock_application_detail.json.return_value = res_app_detail
 
-        mock_api.side_effect = [mock_host_asset, mock_vulnerability_detail, mock_header, mock_application_detail]
+        # Mock vulnerability kb details for detections
+        vuln_kb = get_response('vulnerability_kb_details.xml')
+        mock_kb = Mock(status_code=200)
+        mock_kb.text = vuln_kb
+
+        mock_api.side_effect = [mock_host_asset, mock_vulnerability_detail, mock_kb, mock_header, mock_application_detail]
 
         # Initialization
         Context(Arguments)
@@ -267,7 +293,12 @@ class TestConnector(unittest.TestCase):
         mock_application_detail = Mock(status_code=200)
         mock_application_detail.json.return_value = res_app_detail
 
-        mock_api.side_effect = [mock_host_asset, mock_vulnerability_detail, mock_header, mock_application_detail]
+        # Mock vulnerability kb details for detections
+        vuln_kb = get_response('vulnerability_kb_details.xml')
+        mock_kb = Mock(status_code=200)
+        mock_kb.text = vuln_kb
+
+        mock_api.side_effect = [mock_host_asset, mock_vulnerability_detail, mock_kb, mock_header, mock_application_detail]
 
         # Initialization
         Context(Arguments)
@@ -313,7 +344,12 @@ class TestConnector(unittest.TestCase):
         mock_application_detail = Mock(status_code=200)
         mock_application_detail.json.return_value = res_app_detail
 
-        mock_api.side_effect = [mock_host_asset, mock_vulnerability_detail, mock_header, mock_application_detail]
+        # Mock vulnerability kb details for detections
+        vuln_kb = get_response('vulnerability_kb_details.xml')
+        mock_kb = Mock(status_code=200)
+        mock_kb.text = vuln_kb
+
+        mock_api.side_effect = [mock_host_asset, mock_vulnerability_detail, mock_kb, mock_header, mock_application_detail]
 
         # Initialization
         Context(Arguments)

--- a/connectors/qualys/automation_tests/mock_api/vulnerability_kb_details.xml
+++ b/connectors/qualys/automation_tests/mock_api/vulnerability_kb_details.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE KNOWLEDGE_BASE_VULN_LIST_OUTPUT SYSTEM "https://qualysapi.qg1.apps.qualys.in/api/2.0/fo/knowledge_base/vuln/knowledge_base_vuln_list_output.dtd">
+<KNOWLEDGE_BASE_VULN_LIST_OUTPUT>
+   <RESPONSE>
+      <DATETIME>2022-12-05T15:05:00Z</DATETIME>
+      <VULN_LIST>
+         <VULN>
+            <QID>115068</QID>
+            <VULN_TYPE>Vulnerability</VULN_TYPE>
+            <SEVERITY_LEVEL>3</SEVERITY_LEVEL>
+            <TITLE><![CDATA[Microsoft Power BI Report Server Security Update for May 2020]]></TITLE>
+            <CATEGORY>Windows</CATEGORY>
+            <LAST_SERVICE_MODIFICATION_DATETIME>2021-11-09T23:25:53Z</LAST_SERVICE_MODIFICATION_DATETIME>
+            <PUBLISHED_DATETIME>2020-05-13T04:17:55Z</PUBLISHED_DATETIME>
+            <PATCHABLE>1</PATCHABLE>
+            <SOFTWARE_LIST>
+               <SOFTWARE>
+                  <PRODUCT><![CDATA[powerbi_report_server]]></PRODUCT>
+                  <VENDOR><![CDATA[microsoft]]></VENDOR>
+               </SOFTWARE>
+            </SOFTWARE_LIST>
+            <VENDOR_REFERENCE_LIST>
+               <VENDOR_REFERENCE>
+                  <ID><![CDATA[CVE-2020-1173]]></ID>
+                  <URL><![CDATA[https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2020-1173]]></URL>
+               </VENDOR_REFERENCE>
+            </VENDOR_REFERENCE_LIST>
+            <CVE_LIST>
+               <CVE>
+                  <ID><![CDATA[CVE-2020-1173]]></ID>
+                  <URL><![CDATA[http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1173]]></URL>
+               </CVE>
+            </CVE_LIST>
+            <DIAGNOSIS><![CDATA[A spoofing vulnerability exists in Microsoft Power BI Report Server in the way it validates the content-type of uploaded attachments. An authenticated attacker could exploit the vulnerability by uploading a specially crafted payload and sending it to the user.<P>
+This security update addresses the vulnerability by ensuring Power BI Report Server properly validates content-type of the attachments when uploading and opening.<P>
+Affected Versions:<BR>
+Power BI Report Server versions prior to 15.0.1102.646<P>
+QID Detection Logic:<BR>
+This authenticated QID detects vulnerable versions of RSHostingService.exe by fetching the service installed path from the HKLM\SYSTEM\CurrentControlSet\Services\PowerBIReportServer registry key.<P>
+<B>NOTE:</B>According to the advisory, Microsoft mentions that the most recent version of Power BI is the January 2020 release build is 15.0.1102.777. However, this vulnerability was addressed in the September 2019 release, version 1.6.7236.4246 (Build 15.0.1102.646).<P>]]></DIAGNOSIS>
+            <CONSEQUENCE><![CDATA[Successful exploitation allows an attacker to perform actions and run scripts in the security context of the user.<P>]]></CONSEQUENCE>
+            <SOLUTION><![CDATA[Customers are advised to refer to <A HREF="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2020-1173" TARGET="_blank">CVE-2020-1173</A> for more information pertaining to this vulnerability.
+<P>Patch:<BR>
+Following are links for downloading patches to fix the vulnerabilities:
+<P> <A HREF="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2020-1173" TARGET="_blank">CVE-2020-1173</A>]]></SOLUTION>
+            <PCI_FLAG>0</PCI_FLAG>
+            <THREAT_INTELLIGENCE>
+               <THREAT_INTEL id="13"><![CDATA[Privilege_Escalation]]></THREAT_INTEL>
+            </THREAT_INTELLIGENCE>
+            <DISCOVERY>
+               <REMOTE>0</REMOTE>
+               <AUTH_TYPE_LIST>
+                  <AUTH_TYPE>Windows</AUTH_TYPE>
+               </AUTH_TYPE_LIST>
+               <ADDITIONAL_INFO>Patch Available</ADDITIONAL_INFO>
+            </DISCOVERY>
+         </VULN>
+         <VULN>
+            <QID>115284</QID>
+            <VULN_TYPE>Vulnerability</VULN_TYPE>
+            <SEVERITY_LEVEL>2</SEVERITY_LEVEL>
+            <TITLE><![CDATA[Windows Explorer Autoplay Not Disabled for Default User]]></TITLE>
+            <CATEGORY>Security Policy</CATEGORY>
+            <LAST_SERVICE_MODIFICATION_DATETIME>2019-10-10T08:27:07Z</LAST_SERVICE_MODIFICATION_DATETIME>
+            <PUBLISHED_DATETIME>2005-04-12T07:00:00Z</PUBLISHED_DATETIME>
+            <PATCHABLE>0</PATCHABLE>
+            <SOFTWARE_LIST>
+               <SOFTWARE>
+                  <PRODUCT><![CDATA[None]]></PRODUCT>
+                  <VENDOR><![CDATA[microsoft]]></VENDOR>
+               </SOFTWARE>
+            </SOFTWARE_LIST>
+            <DIAGNOSIS><![CDATA[The setting that prevents applications from any drive to be automatically executed when no user is logged in is not enabled on the host.]]></DIAGNOSIS>
+            <CONSEQUENCE><![CDATA[An attacker may be able to run an unauthorized application.]]></CONSEQUENCE>
+            <SOLUTION><![CDATA[Make sure that the value NoDriveTypeAutoRun is defined under this registry key:
+<P>
+HKU\DEFAULT\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer]]></SOLUTION>
+            <PCI_FLAG>1</PCI_FLAG>
+            <THREAT_INTELLIGENCE>
+               <THREAT_INTEL id="5"><![CDATA[Easy_Exploit]]></THREAT_INTEL>
+               <THREAT_INTEL id="8"><![CDATA[No_Patch]]></THREAT_INTEL>
+            </THREAT_INTELLIGENCE>
+            <DISCOVERY>
+               <REMOTE>0</REMOTE>
+               <AUTH_TYPE_LIST>
+                  <AUTH_TYPE>Windows</AUTH_TYPE>
+               </AUTH_TYPE_LIST>
+            </DISCOVERY>
+         </VULN>
+      </VULN_LIST>
+   </RESPONSE>
+</KNOWLEDGE_BASE_VULN_LIST_OUTPUT>
+<!-- CONFIDENTIAL AND PROPRIETARY INFORMATION. Qualys provides the QualysGuard Service "As Is," without any warranty of any kind. Qualys makes no warranty that the information contained in this report is complete or error-free. Copyright 2022, Qualys, Inc. //-->

--- a/connectors/qualys/connector/qualys_config.json
+++ b/connectors/qualys/connector/qualys_config.json
@@ -4,7 +4,8 @@
 		"asset": "/qps/rest/2.0/search/am/hostasset",
 		"asset_vulnerability": "/api/2.0/fo/asset/host/vm/detection/?action=list",
 		"auth": "/auth",
-		"applications" : "/rest/2.0/search/am/asset?pageSize=300&softwareType=Application"
+		"applications" : "/rest/2.0/search/am/asset?pageSize=300&softwareType=Application",
+		"vuln_knowledgebase" : "/api/2.0/fo/knowledge_base/vuln/?action=list"
 	},
 	"parameter": {
 		"headers": {

--- a/connectors/qualys/requirements.txt
+++ b/connectors/qualys/requirements.txt
@@ -3,3 +3,4 @@ pyopenssl==19.1.0
 car-connector-framework==3.0.0
 xmltodict==0.12.0
 pytest==7.0.0
+html2text==2020.1.16

--- a/connectors/qualys/tests/mock_api/vulnerability_kb_details.xml
+++ b/connectors/qualys/tests/mock_api/vulnerability_kb_details.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE KNOWLEDGE_BASE_VULN_LIST_OUTPUT SYSTEM "https://qualysapi.qg1.apps.qualys.in/api/2.0/fo/knowledge_base/vuln/knowledge_base_vuln_list_output.dtd">
+<KNOWLEDGE_BASE_VULN_LIST_OUTPUT>
+   <RESPONSE>
+      <DATETIME>2022-12-05T15:05:00Z</DATETIME>
+      <VULN_LIST>
+         <VULN>
+            <QID>115068</QID>
+            <VULN_TYPE>Vulnerability</VULN_TYPE>
+            <SEVERITY_LEVEL>3</SEVERITY_LEVEL>
+            <TITLE><![CDATA[Microsoft Power BI Report Server Security Update for May 2020]]></TITLE>
+            <CATEGORY>Windows</CATEGORY>
+            <LAST_SERVICE_MODIFICATION_DATETIME>2021-11-09T23:25:53Z</LAST_SERVICE_MODIFICATION_DATETIME>
+            <PUBLISHED_DATETIME>2020-05-13T04:17:55Z</PUBLISHED_DATETIME>
+            <PATCHABLE>1</PATCHABLE>
+            <SOFTWARE_LIST>
+               <SOFTWARE>
+                  <PRODUCT><![CDATA[powerbi_report_server]]></PRODUCT>
+                  <VENDOR><![CDATA[microsoft]]></VENDOR>
+               </SOFTWARE>
+            </SOFTWARE_LIST>
+            <VENDOR_REFERENCE_LIST>
+               <VENDOR_REFERENCE>
+                  <ID><![CDATA[CVE-2020-1173]]></ID>
+                  <URL><![CDATA[https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2020-1173]]></URL>
+               </VENDOR_REFERENCE>
+            </VENDOR_REFERENCE_LIST>
+            <CVE_LIST>
+               <CVE>
+                  <ID><![CDATA[CVE-2020-1173]]></ID>
+                  <URL><![CDATA[http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1173]]></URL>
+               </CVE>
+            </CVE_LIST>
+            <DIAGNOSIS><![CDATA[A spoofing vulnerability exists in Microsoft Power BI Report Server in the way it validates the content-type of uploaded attachments. An authenticated attacker could exploit the vulnerability by uploading a specially crafted payload and sending it to the user.<P>
+This security update addresses the vulnerability by ensuring Power BI Report Server properly validates content-type of the attachments when uploading and opening.<P>
+Affected Versions:<BR>
+Power BI Report Server versions prior to 15.0.1102.646<P>
+QID Detection Logic:<BR>
+This authenticated QID detects vulnerable versions of RSHostingService.exe by fetching the service installed path from the HKLM\SYSTEM\CurrentControlSet\Services\PowerBIReportServer registry key.<P>
+<B>NOTE:</B>According to the advisory, Microsoft mentions that the most recent version of Power BI is the January 2020 release build is 15.0.1102.777. However, this vulnerability was addressed in the September 2019 release, version 1.6.7236.4246 (Build 15.0.1102.646).<P>]]></DIAGNOSIS>
+            <CONSEQUENCE><![CDATA[Successful exploitation allows an attacker to perform actions and run scripts in the security context of the user.<P>]]></CONSEQUENCE>
+            <SOLUTION><![CDATA[Customers are advised to refer to <A HREF="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2020-1173" TARGET="_blank">CVE-2020-1173</A> for more information pertaining to this vulnerability.
+<P>Patch:<BR>
+Following are links for downloading patches to fix the vulnerabilities:
+<P> <A HREF="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2020-1173" TARGET="_blank">CVE-2020-1173</A>]]></SOLUTION>
+            <PCI_FLAG>0</PCI_FLAG>
+            <THREAT_INTELLIGENCE>
+               <THREAT_INTEL id="13"><![CDATA[Privilege_Escalation]]></THREAT_INTEL>
+            </THREAT_INTELLIGENCE>
+            <DISCOVERY>
+               <REMOTE>0</REMOTE>
+               <AUTH_TYPE_LIST>
+                  <AUTH_TYPE>Windows</AUTH_TYPE>
+               </AUTH_TYPE_LIST>
+               <ADDITIONAL_INFO>Patch Available</ADDITIONAL_INFO>
+            </DISCOVERY>
+         </VULN>
+         <VULN>
+            <QID>115284</QID>
+            <VULN_TYPE>Vulnerability</VULN_TYPE>
+            <SEVERITY_LEVEL>2</SEVERITY_LEVEL>
+            <TITLE><![CDATA[Windows Explorer Autoplay Not Disabled for Default User]]></TITLE>
+            <CATEGORY>Security Policy</CATEGORY>
+            <LAST_SERVICE_MODIFICATION_DATETIME>2019-10-10T08:27:07Z</LAST_SERVICE_MODIFICATION_DATETIME>
+            <PUBLISHED_DATETIME>2005-04-12T07:00:00Z</PUBLISHED_DATETIME>
+            <PATCHABLE>0</PATCHABLE>
+            <SOFTWARE_LIST>
+               <SOFTWARE>
+                  <PRODUCT><![CDATA[None]]></PRODUCT>
+                  <VENDOR><![CDATA[microsoft]]></VENDOR>
+               </SOFTWARE>
+            </SOFTWARE_LIST>
+            <DIAGNOSIS><![CDATA[The setting that prevents applications from any drive to be automatically executed when no user is logged in is not enabled on the host.]]></DIAGNOSIS>
+            <CONSEQUENCE><![CDATA[An attacker may be able to run an unauthorized application.]]></CONSEQUENCE>
+            <SOLUTION><![CDATA[Make sure that the value NoDriveTypeAutoRun is defined under this registry key:
+<P>
+HKU\DEFAULT\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer]]></SOLUTION>
+            <PCI_FLAG>1</PCI_FLAG>
+            <THREAT_INTELLIGENCE>
+               <THREAT_INTEL id="5"><![CDATA[Easy_Exploit]]></THREAT_INTEL>
+               <THREAT_INTEL id="8"><![CDATA[No_Patch]]></THREAT_INTEL>
+            </THREAT_INTELLIGENCE>
+            <DISCOVERY>
+               <REMOTE>0</REMOTE>
+               <AUTH_TYPE_LIST>
+                  <AUTH_TYPE>Windows</AUTH_TYPE>
+               </AUTH_TYPE_LIST>
+            </DISCOVERY>
+         </VULN>
+      </VULN_LIST>
+   </RESPONSE>
+</KNOWLEDGE_BASE_VULN_LIST_OUTPUT>
+<!-- CONFIDENTIAL AND PROPRIETARY INFORMATION. Qualys provides the QualysGuard Service "As Is," without any warranty of any kind. Qualys makes no warranty that the information contained in this report is complete or error-free. Copyright 2022, Qualys, Inc. //-->

--- a/connectors/qualys/tests/mock_api/vulnerability_kb_error_details.xml
+++ b/connectors/qualys/tests/mock_api/vulnerability_kb_error_details.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE SIMPLE_RETURN SYSTEM "https://qualysapi.qg1.apps.qualys.in/api/2.0/simple_return.dtd">
+<SIMPLE_RETURN>
+  <RESPONSE>
+    <DATETIME>2022-12-05T16:58:29Z</DATETIME>
+    <CODE>1905</CODE>
+    <TEXT>parameter ids has invalid value: 35234567.171 (neither a positive integer nor a range: 35234567.171)</TEXT>
+  </RESPONSE>
+</SIMPLE_RETURN>

--- a/connectors/qualys/tests/test_inc_import.py
+++ b/connectors/qualys/tests/test_inc_import.py
@@ -33,7 +33,12 @@ class TestIncImportFunctions(unittest.TestCase):
         mock_application_detail = Mock(status_code=200)
         mock_application_detail.json.return_value = res_application_detail
 
-        mock_api.side_effect = [mock_host_asset, mock_vulnerability_detail, mock_header, mock_application_detail]
+        # Mock vulnerability kb details for detections
+        vuln_kb = get_response('vulnerability_kb_details.xml')
+        mock_kb = Mock(status_code=200)
+        mock_kb.text = vuln_kb
+
+        mock_api.side_effect = [mock_host_asset, mock_vulnerability_detail, mock_kb, mock_header, mock_application_detail]
         inc_import_obj.get_data_for_delta(data_handler.get_report_time(), None)
 
         # Initiate incremental create and update
@@ -71,7 +76,12 @@ class TestIncImportFunctions(unittest.TestCase):
         mock_application_detail = Mock(status_code=200)
         mock_application_detail.json.return_value = res_application_detail
 
-        mock_api.side_effect = [mock_host_asset, mock_vulnerability_detail, mock_header, mock_application_detail]
+        # Mock vulnerability kb details for detections
+        vuln_kb = get_response('vulnerability_kb_details.xml')
+        mock_kb = Mock(status_code=200)
+        mock_kb.text = vuln_kb
+
+        mock_api.side_effect = [mock_host_asset, mock_vulnerability_detail, mock_kb, mock_header, mock_application_detail]
         inc_import_obj.get_data_for_delta(data_handler.get_report_time(), None)
 
         # Initiate incremental create and update
@@ -109,7 +119,12 @@ class TestIncImportFunctions(unittest.TestCase):
         mock_application_detail = Mock(status_code=200)
         mock_application_detail.json.return_value = res_application_detail
 
-        mock_api.side_effect = [mock_host_asset, mock_vulnerability_detail, mock_header, mock_application_detail]
+        # Mock vulnerability kb details for detections
+        vuln_kb = get_response('vulnerability_kb_details.xml')
+        mock_kb = Mock(status_code=200)
+        mock_kb.text = vuln_kb
+
+        mock_api.side_effect = [mock_host_asset, mock_vulnerability_detail, mock_kb, mock_header, mock_application_detail]
         active_edge = {}
         for key, value in res_active_edges.items():
             active_edge[key] = set(value)

--- a/connectors/qualys/tests/test_initial_import.py
+++ b/connectors/qualys/tests/test_initial_import.py
@@ -33,7 +33,12 @@ class TestInitialImportFunctions(unittest.TestCase):
         mock_application_detail = Mock(status_code=200)
         mock_application_detail.json.return_value = res_application_detail
 
-        mock_api.side_effect = [mock_host_asset, mock_vulnerability_detail, mock_header, mock_application_detail]
+        # Mock vulnerability kb details for detections
+        vuln_kb = get_response('vulnerability_kb_details.xml')
+        mock_kb = Mock(status_code=200)
+        mock_kb.text = vuln_kb
+
+        mock_api.side_effect = [mock_host_asset, mock_vulnerability_detail, mock_kb, mock_header, mock_application_detail]
 
         # Initiate full import
         actual_response = create_vertices_edges(full_import_obj)
@@ -69,7 +74,12 @@ class TestInitialImportFunctions(unittest.TestCase):
         mock_application_detail = Mock(status_code=200)
         mock_application_detail.json.return_value = res_app_detail
 
-        mock_api.side_effect = [mock_host_asset, mock_vulnerability_detail, mock_header, mock_application_detail]
+        # Mock vulnerability kb details for detections
+        vuln_kb = get_response('vulnerability_kb_details.xml')
+        mock_kb = Mock(status_code=200)
+        mock_kb.text = vuln_kb
+
+        mock_api.side_effect = [mock_host_asset, mock_vulnerability_detail, mock_kb, mock_header, mock_application_detail]
 
         # Initiate full import
         actual_response = create_vertices_edges(full_import)
@@ -117,7 +127,12 @@ class TestInitialImportFunctions(unittest.TestCase):
         mock_application_detail = Mock(status_code=200)
         mock_application_detail.json.return_value = res_application_detail
 
-        mock_api.side_effect = [mock_host_asset, mock_vulnerability_detail, mock_header, mock_application_detail]
+        # Mock vulnerability kb details for detections
+        vuln_kb = get_response('vulnerability_kb_details.xml')
+        mock_kb = Mock(status_code=200)
+        mock_kb.text = vuln_kb
+
+        mock_api.side_effect = [mock_host_asset, mock_vulnerability_detail, mock_kb, mock_header, mock_application_detail]
 
         # Initiate full import
         actual_response = create_vertices_edges(full_import_obj)
@@ -153,7 +168,12 @@ class TestInitialImportFunctions(unittest.TestCase):
         mock_application_detail = Mock(status_code=200)
         mock_application_detail.json.return_value = res_application_detail
 
-        mock_api.side_effect = [mock_host_asset, mock_vulnerability_detail, mock_header, mock_application_detail]
+        # Mock vulnerability kb details for detections
+        vuln_kb = get_response('vulnerability_kb_details.xml')
+        mock_kb = Mock(status_code=200)
+        mock_kb.text = vuln_kb
+
+        mock_api.side_effect = [mock_host_asset, mock_vulnerability_detail, mock_kb, mock_header, mock_application_detail]
 
         # Initiate full import
         actual_response = create_vertices_edges(full_import_obj)
@@ -189,7 +209,12 @@ class TestInitialImportFunctions(unittest.TestCase):
         mock_application_detail = Mock(status_code=200)
         mock_application_detail.json.return_value = res_application_detail
 
-        mock_api.side_effect = [mock_host_asset, mock_vulnerability_detail, mock_header, mock_application_detail]
+        # Mock vulnerability kb details for detections
+        vuln_kb = get_response('vulnerability_kb_details.xml')
+        mock_kb = Mock(status_code=200)
+        mock_kb.text = vuln_kb
+
+        mock_api.side_effect = [mock_host_asset, mock_vulnerability_detail, mock_kb, mock_header, mock_application_detail]
 
         # Initiate full import
         actual_response = create_vertices_edges(full_import_obj)

--- a/connectors/qualys/tests/test_server_access.py
+++ b/connectors/qualys/tests/test_server_access.py
@@ -59,10 +59,33 @@ class TestAssetServer(unittest.TestCase):
         mock_vuln_page_2 = Mock(status_code=200)
         mock_vuln_page_2.text = vuln_page_2
 
-        mock_api.side_effect = [mock_vuln_page_1, mock_vuln_page_2]
+        # Mock vulnerability kb details for detections
+        vuln_kb = get_response('vulnerability_kb_details.xml')
+        mock_kb = Mock(status_code=200)
+        mock_kb.text = vuln_kb
+
+        mock_api.side_effect = [mock_vuln_page_1, mock_vuln_page_2, mock_kb]
 
         # Initiate get_vulnerabilities function
         actual_response = context().asset_server.get_vulnerabilities()
+
+        assert actual_response is not None
+
+    @patch('connector.server_access.AssetServer.get_collection')
+    def test_get_knowledge_base_vuln_list(self, mock_api):
+        """Unit test for get_vulnerabilities.
+         If vulnerability api having pagination."""
+
+        # mock vulnerability api
+        vuln_kb = get_response('vulnerability_kb_details.xml')
+        mock_vuln= Mock(status_code=200)
+        mock_vuln.text = vuln_kb
+
+        mock_api.side_effect = [mock_vuln]
+
+        # Initiate get_vulnerabilities function
+        qid_list = []
+        actual_response = context().asset_server.get_knowledge_base_vuln_list(qid_list)
 
         assert actual_response is not None
 
@@ -155,3 +178,23 @@ class TestAssetServer(unittest.TestCase):
             error = str(e)
 
         assert 'authenticationFailure' in error
+
+    @patch('connector.server_access.AssetServer.get_collection')
+    def test_get_knowledge_base_vuln_list_error(self, mock_api):
+        """Unit test for get_vulnerabilities.
+         If vulnerability api having pagination."""
+
+        # mock vulnerability api
+        vuln_kb = get_response('vulnerability_kb_error_details.xml')
+        mock_vuln = Mock(status_code=400)
+        mock_vuln.text = vuln_kb
+
+        mock_api.side_effect = [mock_vuln]
+
+        # Initiate get_vulnerabilities function
+        qid_list = []
+        try:
+            actual_response = context().asset_server.get_knowledge_base_vuln_list(qid_list)
+        except Exception as e:
+            error = str(e)
+        assert "parameter ids has invalid value" in error

--- a/connectors/qualys/tests/test_utils.py
+++ b/connectors/qualys/tests/test_utils.py
@@ -26,6 +26,7 @@ class Arguments:
     debug = None
     connector_name = "Qualys"
     version = "1.0.0.0"
+    update_existing_vulnerability_cve = False
 
 
 def full_import_initialization():


### PR DESCRIPTION
Qualys connector updated to add QID associated vulnerability CVE ids and CVSS in vulnerability node.
Able to get one CVSS score( cvss_v2, cvss_v3) for the multiple CVEs associated with a particular vulnerability. The maximum value of this score is considered as risk score for the vulnerability.

For existing connector deployments,
a new flag '-update_existing_vulnerability_cve' added to update existing vulnerability nodes with CVE ids and score in CAR DB.  Run the incremental import once with flag to update the CAR DB vulnerability node.
