### PR TITLE
Update cryptography and pyopenssl

### DIFF
--- a/deployment/Dockerfile.part
+++ b/deployment/Dockerfile.part
@@ -10,8 +10,8 @@ USER root
 RUN  microdnf install openssl python39-pip
 COPY requirements.txt requirements.txt
 RUN  python3 -m pip install --upgrade pip
-RUN  pip3 install 'cryptography==42.0.5'
-RUN  pip3 install 'pyopenssl==24.1.0'
+RUN  pip3 install 'cryptography==44.0.2'
+RUN  pip3 install 'pyopenssl==25.0.0'
 RUN  pip3 install -r requirements.txt --no-cache-dir 
 
 FROM base

--- a/deployment/build.sh
+++ b/deployment/build.sh
@@ -141,8 +141,8 @@ python -V
 python3 -V
 docker version
 
-pip3 install 'cryptography==42.0.5'
-pip3 install 'pyopenssl==24.1.0'
+pip3 install 'cryptography==44.0.2'
+pip3 install 'pyopenssl==25.0.0'
 
 
 if [ ! -d "$BUILD_HOME" ]; then


### PR DESCRIPTION
# PR: Update cryptography and pyopenssl Versions in Dockerfile and build.sh

## Description
This PR updates the versions of the `cryptography` and `pyopenssl` packages referenced in the Dockerfile and build.sh file. The update bumps the `cryptography` version from v42 to v44 to ensure that a secure version is used and cached in the containers. 

This caching is important for dependencies that may reference `cryptography` as a transient dependency; for instance `jwcrypto` has a transient-dependency to `cryptography`. `jwcrypto` is a required import for the `car-connector-framework` which car-connectors reference and in return inherit this transient-dependency on cryptography through their dependency on the car-connector-framework.

## Vulnerability
The previous version of `cryptography` (v42) contains a known vulnerability. By upgrading to v44, we mitigate the security risk posed by the vulnerable version, ensuring that our dependency chain remains secure.

## Compatibility
- **cryptography:**  
  The new version (v44) is cached through the Dockerfile and build.sh, and meets the requirements of all transient dependency references that rely on it.
- **pyopenssl:**  
  Although its usage within car-connectors is not immediately apparent, the update ensures that there are no conflicts with dependency constraints—specifically, to prevent `pyopenssl` from imposing restrictions on the `cryptography` package version.

## Additional Notes
- The update is strictly for dependency management and does not affect the core functionality of the repository.
- These changes are part of our ongoing efforts to maintain a secure and compatible software environment.
- Future dependency audits will continue to ensure that no vulnerable packages are included in our build.
