### PR TITLE
upgrade/cryptography 49.0.0

### DIFF
--- a/connectors/proofpoint/requirements.txt
+++ b/connectors/proofpoint/requirements.txt
@@ -1,2 +1,2 @@
 car-connector-framework==3.0.0
-urllib3==2.6.3
+urllib3>=2.6.3,<3

--- a/deployment/Dockerfile.part
+++ b/deployment/Dockerfile.part
@@ -10,8 +10,8 @@ USER root
 RUN  microdnf install openssl python39-pip
 COPY requirements.txt requirements.txt
 RUN  python3 -m pip install --upgrade pip
-RUN  pip3 install 'cryptography==46.0.7'
-RUN  pip3 install 'pyopenssl==26.0.0'
+RUN  pip3 install 'cryptography>=49.0.0'
+RUN  pip3 install 'pyopenssl>=26.3.0'
 RUN  pip3 install -r requirements.txt --no-cache-dir 
 
 FROM base

--- a/deployment/build.sh
+++ b/deployment/build.sh
@@ -141,8 +141,8 @@ python -V
 python3 -V
 docker version
 
-pip3 install 'cryptography==46.0.7'
-pip3 install 'pyopenssl==26.0.0'
+pip3 install 'cryptography>=49.0.0'
+pip3 install 'pyopenssl>=26.3.0'
 
 
 if [ ! -d "$BUILD_HOME" ]; then


### PR DESCRIPTION
### Description

upgrading pyopenssl and cryptography packages that get installed during builds so as to address open vulnerabilities.

also updated proofpoint urllib3 dependency from a hard pin to a range pin.

---

### Validation

Check pyopenssl & cryptography compatibility with:
```
pip3 install 'cryptography>=49.0.0' 'pyopenssl>=26.3.0' --dry-run 2>&1
```