### PR TITLE
fix(gcp): bump dependencies to mitigate CVE-2026-0994

### DIFF
--- a/connectors/gcp/requirements.txt
+++ b/connectors/gcp/requirements.txt
@@ -1,8 +1,8 @@
 car-connector-framework==3.0.2
-google-cloud-asset==3.19.0
-google-cloud-resource-manager==1.9.1
-google-cloud-securitycenter==1.19.1
-google-cloud-logging==3.5.0
-google-auth==2.17.1
-google-api-python-client==2.74.0
+google-cloud-asset>=4.4.0,<5
+google-cloud-resource-manager>=1.18.0,<2
+google-cloud-securitycenter>=1.46.0,<2
+google-cloud-logging>=3.16.1,<4
+google-auth>=2.56.2,<3
+google-api-python-client>=2.198.0,<3
 urllib3>=2.6.3,<3


### PR DESCRIPTION
## fix(gcp): bump dependencies to mitigate CVE-2026-0994

---

### 1. Description

Bumps all GCP connector Python dependencies to their latest compatible versions in order to mitigate [CVE-2026-0994](https://nvd.nist.gov/vuln/detail/CVE-2026-0994) — a denial-of-service vulnerability in `google.protobuf.json_format.ParseDict()` where the `max_recursion_depth` limit can be bypassed when parsing nested `google.protobuf.Any` messages, eventually exhausting Python's recursion stack and causing a `RecursionError`.

---

### 2. Proposed Changes

Updated `connectors/gcp/requirements.txt` with the following version bumps:

| Package | From | To |
|---|---|---|
| `google-cloud-asset` | `3.19.0` | `>=4.4.0,<5` |
| `google-cloud-resource-manager` | `1.9.1` | `>=1.18.0,<2` |
| `google-cloud-securitycenter` | `1.19.1` | `>=1.46.0,<2` |
| `google-cloud-logging` | `3.5.0` | `>=3.16.1,<4` |
| `google-auth` | `2.17.1` | `>=2.56.2,<3` |
| `google-api-python-client` | `2.74.0` | `>=2.198.0,<3` |
| `urllib3` | — | `>=2.6.3,<3` |

**Changelogs:**
- [google-api-python-client](https://github.com/googleapis/google-api-python-client/blob/main/CHANGELOG.md)
- [google-auth](https://github.com/googleapis/google-cloud-python/blob/main/packages/google-auth/CHANGELOG.md)
- [google-cloud-logging](https://github.com/googleapis/google-cloud-python/blob/main/packages/google-cloud-logging/CHANGELOG.md)
- [google-cloud-securitycenter](https://github.com/googleapis/google-cloud-python/blob/main/packages/google-cloud-securitycenter/CHANGELOG.md)
- [google-cloud-resource-manager](https://github.com/googleapis/google-cloud-python/blob/main/packages/google-cloud-resource-manager/CHANGELOG.md)
- [google-cloud-asset](https://docs.cloud.google.com/python/docs/reference/cloudasset/latest/changelog)

**Notable breaking change assessed — `google-cloud-asset` 3.x → 4.x:**

The `asset_v1p4beta1` sub-module was removed in `4.4.0`. This has been confirmed as a non-issue — the GCP connector does not import or depend on `asset_v1p4beta1`.

- Present in [`3.30.1`](https://github.com/googleapis/google-cloud-python/tree/google-cloud-asset-v3.30.1/packages/google-cloud-asset/google/cloud)
- Removed in [`4.4.0`](https://github.com/googleapis/google-cloud-python/tree/google-cloud-asset-v4.4.0/packages/google-cloud-asset/google/cloud)

---

### 3. Testing & Validation

All existing GCP connector unit tests pass with no regressions:

```
Before: 33 passed, 4 warnings
After:  33 passed, 7 warnings
```

The 3 additional warnings are `FutureWarning`s emitted by the upgraded Google Cloud libraries indicating that Python 3.10 will reach end-of-life on **2026-10-04** and will stop being supported in new releases. These are non-actionable at this time — the project is already tracking a Python version bump ahead of that date.

Example warning:
```
FutureWarning: You are using a Python version (3.10.19) which Google will stop 
supporting in new releases of google.cloud.asset_v1 once it reaches its end of 
life (2026-10-04). Please upgrade to the latest Python version, or at least 
Python 3.11, to continue receiving updates for google.cloud.asset_v1 past that date.
```
